### PR TITLE
add --reuse-window to .desktop file

### DIFF
--- a/com.visualstudio.code.json
+++ b/com.visualstudio.code.json
@@ -105,7 +105,7 @@
                     "rmdir usr",
                     "install -Dm644  share/pixmaps/code.png export/share/icons/hicolor/512x512/apps/com.visualstudio.code.png",
                     "install -Dm644  share/applications/code.desktop export/share/applications/com.visualstudio.code.desktop",                
-                    "desktop-file-edit --set-key=Exec --set-value='code %F' export/share/applications/com.visualstudio.code.desktop",
+                    "desktop-file-edit --set-key=Exec --set-value='code --reuse-window %F' export/share/applications/com.visualstudio.code.desktop",
                     "desktop-file-edit --set-key=Icon --set-value='com.visualstudio.code' export/share/applications/com.visualstudio.code.desktop"        
                 ]
             },


### PR DESCRIPTION
this fixes opening files in file managers