### PR TITLE
added flags to handle kde global menu

### DIFF
--- a/com.visualstudio.code.json
+++ b/com.visualstudio.code.json
@@ -21,7 +21,10 @@
       "--talk-name=org.freedesktop.Notifications",
       "--talk-name=org.freedesktop.secrets",
       "--talk-name=org.freedesktop.Flatpak",
-      "--env=NPM_CONFIG_GLOBALCONFIG=/app/etc/npmrc"
+      "--env=NPM_CONFIG_GLOBALCONFIG=/app/etc/npmrc",
+      "--filesystem=xdg-config/kdeglobals:ro",
+      "--talk-name=com.canonical.AppMenu.Registrar",
+      "--talk-name=com.canonical.AppMenu.Registrar.*"
     ],
   "modules": [
     {


### PR DESCRIPTION
Those permissions allow to use kde global menu (who work on the non-flatpak version) 