### PR TITLE
Drop the i386 architecture

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -96,9 +96,3 @@ modules:
         url: https://vscode-update.azurewebsites.net/1.35.1/linux-deb-x64/stable
         sha256: c3bb7a6d7953ff4093b8a7229227ad4a9587900866c7e867710086dcd42ba482
         size: 48458546
-      - type: extra-data
-        filename: code.deb
-        only-arches: [i386]
-        url: https://vscode-update.azurewebsites.net/1.35.1/linux-deb-ia32/stable
-        sha256: d90f13b9e4004928fdb51791ff586dc7f4b43f3d00080dac0be5f7cf6261d0c2
-        size: 49411812

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,5 @@
 {
-  "only-arches": ["i386", "x86_64"],
+  "only-arches": ["x86_64"],
   "publish-delay-hours": 1,
   "skip-appstream-check": true
 }

--- a/update-vscode-flatpak.py
+++ b/update-vscode-flatpak.py
@@ -24,7 +24,7 @@ if VERSION in data['modules'][-1]['sources'][-1]['url']:
     print('No update needed. Current version: ' + VERSION)
     sys.exit()
 
-ARCHES = {'x64': -2, 'ia32': -1}
+ARCHES = {'x64': -1}
 
 for arch, pos in ARCHES.items():
     source_entry = data['modules'][-1]['sources'][pos]


### PR DESCRIPTION
Microsoft [has ended](https://code.visualstudio.com/updates/v1_36#_linux-32bit-support-ends) support for x86-32 on Linux with release 1.36.

