### PR TITLE
Add x-checker-data for external data checker

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -96,3 +96,9 @@ modules:
         url: https://update.code.visualstudio.com/1.37.1/linux-deb-x64/stable
         sha256: c1683a4871f5e374555960d22dbeb43b1ebadd24ba6c1577ee79e63cefe07981
         size: 54972118
+        x-checker-data:
+          type: debian-repo
+          package-name: code
+          root: http://packages.microsoft.com/repos/vscode
+          dist: stable
+          component: main


### PR DESCRIPTION
This allows PRs for new versions to be generated automatically.  See
https://github.com/endlessm/flatpak-external-data-checker/ for more
information.

The resulting URLs will be of this form: https://packages.microsoft.com/repos/vscode/pool/main/c/code/code_1.37.1-1565886362_amd64.deb

This is different to the current URL, but it's the same data. Both URLs redirect into Microsoft's CDN.

I don't recommend merging this before
https://github.com/endlessm/flatpak-external-data-checker/pull/29 is
merged, or else the checker will open another PR with a CDN URL like
https://github.com/flathub/com.visualstudio.code/pull/99. This is a
regression I introduced a little while ago while doing some refactoring.