### PR TITLE
Option to enable all SDK extensions

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -13,13 +13,13 @@ if [ ! -f ${FIRST_RUN} ]; then
   touch ${FIRST_RUN}
 fi
 
-if [ "$FLATPAK_ENABLE_SDK" = "*" ]; then
+if [ "$FLATPAK_ENABLE_SDK_EXT" = "*" ]; then
   SDK=()
   for d in /usr/lib/sdk/*; do
     SDK+=("${d##*/}")
   done
 else
-  IFS=',' read -ra SDK <<< "$FLATPAK_ENABLE_SDK"
+  IFS=',' read -ra SDK <<< "$FLATPAK_ENABLE_SDK_EXT"
 fi
 
 for i in "${SDK[@]}"; do

--- a/code.sh
+++ b/code.sh
@@ -4,6 +4,10 @@ set -e
 
 FIRST_RUN="${XDG_CONFIG_HOME}/flatpak-vscode-first-run"
 
+function msg() {
+  echo "flatpak-vscode: $*" >&2
+}
+
 if [ ! -f ${FIRST_RUN} ]; then
   WARNING_FILE="/app/share/vscode/flatpak-warning.txt"
   touch ${FIRST_RUN}
@@ -20,11 +24,14 @@ fi
 
 for i in "${SDK[@]}"; do
   if [[ -d /usr/lib/sdk/$i ]]; then
+    msg "Enabling SDK extension \"$i\""
     if [[ -f /usr/lib/sdk/$i/enable.sh ]]; then
       . /usr/lib/sdk/$i/enable.sh
     else
       export PATH=$PATH:/usr/lib/sdk/$i/bin
     fi
+  else
+    msg "Requested SDK extension \"$i\" is not installed"
   fi
 done
 

--- a/code.sh
+++ b/code.sh
@@ -9,7 +9,15 @@ if [ ! -f ${FIRST_RUN} ]; then
   touch ${FIRST_RUN}
 fi
 
-IFS=',' read -ra SDK <<< "$FLATPAK_ENABLE_SDK"
+if [ "$FLATPAK_ENABLE_SDK" = "*" ]; then
+  SDK=()
+  for d in /usr/lib/sdk/*; do
+    SDK+=("${d##*/}")
+  done
+else
+  IFS=',' read -ra SDK <<< "$FLATPAK_ENABLE_SDK"
+fi
+
 for i in "${SDK[@]}"; do
   if [[ -d /usr/lib/sdk/$i ]]; then
     if [[ -f /usr/lib/sdk/$i/enable.sh ]]; then

--- a/flatpak-warning.txt
+++ b/flatpak-warning.txt
@@ -34,7 +34,7 @@ To get support for additional languages, you have to install SDK extensions, e.g
 
   $ flatpak install flathub org.freedesktop.Sdk.Extension.dotnet
   $ flatpak install flathub org.freedesktop.Sdk.Extension.golang
-  $ FLATPAK_ENABLE_SDK=dotnet,golang flatpak run com.visualstudio.code
+  $ FLATPAK_ENABLE_SDK_EXT=dotnet,golang flatpak run com.visualstudio.code
 
 You can use
 


### PR DESCRIPTION
If `FLATPAK_ENABLE_SDK` is set to `*`, enable all installed SDK extensions. Fixes #143.