### PR TITLE
Allow talk to org.freedesktop.login1 on system bus

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -27,6 +27,7 @@ finish-args:
   - --filesystem=xdg-config/kdeglobals:ro
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=com.canonical.AppMenu.Registrar.*
+  - --system-talk-name=org.freedesktop.login1
 add-extensions:
   com.visualstudio.code.tool:
     directory: tools


### PR DESCRIPTION
There are complaints in the logs about not being able to use the logind service on the system bus.
I guess VSCode wants to be aware of suspend and resume.

Fixes #160