### PR TITLE
Drop the Electron2 base app

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -1,7 +1,5 @@
 app-id: com.visualstudio.code
 default-branch: stable
-base: org.electronjs.Electron2.BaseApp
-base-version: '19.08'
 runtime: org.freedesktop.Sdk
 runtime-version: '19.08'
 sdk: org.freedesktop.Sdk


### PR DESCRIPTION
It no longer provides anything of use to the app.