### PR TITLE
Use runtime branch for tools extensions

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -30,6 +30,7 @@ add-extensions:
   com.visualstudio.code.tool:
     directory: tools
     subdirectories: true
+    version: '19.08'
     add-ld-path: lib
     no-autodownload: true
 cleanup:

--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -30,7 +30,7 @@ add-extensions:
   com.visualstudio.code.tool:
     directory: tools
     subdirectories: true
-    version: '19.08'
+    version: '20.08'
     add-ld-path: lib
     no-autodownload: true
 cleanup:


### PR DESCRIPTION
As suggested in https://github.com/flathub/flathub/pull/1417#issuecomment-668550338: tools extensions effectively depend on the SDK, not the VS Code app, so should be tied to the SDK branch instead.
As long as we don't have any actual tool ext on Flathub, I believe it's safe to change the extension point behavior.