### PR TITLE
Set terminal.integrated.fontFamily to an available mono font

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -4,6 +4,7 @@ set -e
 shopt -s nullglob
 
 FIRST_RUN="${XDG_CONFIG_HOME}/flatpak-vscode-first-run"
+SETTINGS_FILE="${XDG_CONFIG_HOME}/Code/User/settings.json"
 
 function msg() {
   echo "flatpak-vscode: $*" >&2
@@ -12,6 +13,14 @@ function msg() {
 if [ ! -f ${FIRST_RUN} ]; then
   WARNING_FILE="/app/share/vscode/flatpak-warning.txt"
   touch ${FIRST_RUN}
+
+  SETTINGS_TEMPLATE_FILE="/app/share/vscode/settings.json"
+  mkdir -p "$(dirname "${SETTINGS_FILE}")"
+  touch ${SETTINGS_FILE}
+  (
+  export FIRST_MONO_FONT=$(fc-list :mono | awk -F: '{print $2}' | sort -u | head -n 1 | xargs);
+  envsubst < "${SETTINGS_TEMPLATE_FILE}" > "${SETTINGS_FILE}"
+  )
 fi
 
 PYTHON_SITEDIR=$(python3 <<EOFPYTHON

--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -54,6 +54,7 @@ modules:
       - install -Dm644 com.visualstudio.code.desktop -t /app/share/applications
       - install -Dm644 npmrc -t /app/etc
       - install -Dm644 flatpak-warning.txt -t /app/share/vscode
+      - install -Dm644 settings.json -t /app/share/vscode
       - install -D apply_extra -t /app/bin
       - cp /usr/bin/ar /app/bin
       - ARCH_TRIPLE=$(gcc --print-multiarch) && cp /usr/lib/${ARCH_TRIPLE}/libbfd-*.so
@@ -72,6 +73,8 @@ modules:
         path: code.sh
       - type: file
         path: flatpak-warning.txt
+      - type: file
+        path: settings.json
       - type: file
         path: npmrc
       - type: file

--- a/settings.json
+++ b/settings.json
@@ -1,0 +1,3 @@
+{
+        "terminal.integrated.fontFamily": "'${FIRST_MONO_FONT}'"
+}


### PR DESCRIPTION
The default setting from vscode invoke an unavailable fontFamilly and make the terminal show ugly, this PR set it to an available mono font in the first run.