### PR TITLE
Add support for Discord Presence

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -60,5 +60,10 @@ for i in "${SDK[@]}"; do
   fi
 done
 
+# https://marketplace.visualstudio.com/items?itemName=icrawl.discord-vscode
+for i in {0..9}; do
+    test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
+done
+
 exec env PATH="${PATH}:${XDG_DATA_HOME}/node_modules/bin" \
   /app/extra/vscode/bin/code --extensions-dir=${XDG_DATA_HOME}/vscode/extensions "$@" ${WARNING_FILE}

--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -23,6 +23,7 @@ finish-args:
   - --env=NPM_CONFIG_GLOBALCONFIG=/app/etc/npmrc
   - --env=LD_LIBRARY_PATH=/app/lib
   - --filesystem=xdg-config/kdeglobals:ro
+  - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=com.canonical.AppMenu.Registrar.*
   - --system-talk-name=org.freedesktop.login1


### PR DESCRIPTION
This PR enables access to the Discord IPC socket needed by the [Discord Presence](https://marketplace.visualstudio.com/items?itemName=icrawl.discord-vscode) plugin in order to function OOTB.

This PR is similar to the ones I have created for [IntelliJ IDEA Community](https://github.com/flathub/com.jetbrains.IntelliJ-IDEA-Community/pull/70) and [IntelliJ IDEA Ultimate](https://github.com/flathub/com.jetbrains.IntelliJ-IDEA-Ultimate/pull/74).