### PR TITLE
Enable Wayland socket

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -11,6 +11,7 @@ finish-args:
   - --require-version=0.10.3
   - --share=ipc
   - --socket=x11
+  - --socket=wayland
   - --socket=pulseaudio
   - --socket=ssh-auth
   - --share=network


### PR DESCRIPTION
You can run vscode in native Wayland, but it only works if the socket is enabled.
When the socket is enabled run: `flatpak run com.visualstudio.code --enable-features=UseOzonePlatform --ozone-platform=wayland`
Note window decorations currently won't be present in GNOME when running in native Wayland.