### PR TITLE
Add Kerberos

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -110,3 +110,14 @@ modules:
           root: http://packages.microsoft.com/repos/code
           dist: stable
           component: main
+
+  - name: kerberos
+    subdir: src
+    post-install:
+    - install -Dm644 ../krb5.conf /app/etc/krb5.conf
+    sources:
+    - type: archive
+      url: https://kerberos.org/dist/krb5/1.19/krb5-1.19.1.tar.gz
+      sha256: fa16f87eb7e3ec3586143c800d7eaff98b5e0dcdf0772af7d98612e49dbeb20b
+    - type: file
+      path: krb5.conf

--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -117,7 +117,7 @@ modules:
     - install -Dm644 ../krb5.conf /app/etc/krb5.conf
     sources:
     - type: archive
-      url: https://kerberos.org/dist/krb5/1.19/krb5-1.19.1.tar.gz
-      sha256: fa16f87eb7e3ec3586143c800d7eaff98b5e0dcdf0772af7d98612e49dbeb20b
+      url: https://kerberos.org/dist/krb5/1.19/krb5-1.19.2.tar.gz
+      sha256: 10453fee4e3a8f8ce6129059e5c050b8a65dab1c257df68b99b3112eaa0cdf6a
     - type: file
       path: krb5.conf

--- a/krb5.conf
+++ b/krb5.conf
@@ -1,0 +1,9 @@
+[libdefaults]
+    dns_lookup_realm = false
+    ticket_lifetime = 24h
+    renew_lifetime = 7d
+    forwardable = true
+    rdns = false
+    pkinit_anchors = FILE:/etc/ssl/certs/ca-certificates.crt
+    spake_preauth_groups = edwards25519
+    default_ccache_name = KCM:


### PR DESCRIPTION
Add kerberos. Fixes dynamic linking issues with OmniSharp bundled libraries (libmono-native.so).

Credits: https://github.com/flathub/org.mozilla.firefox.BaseApp/commit/f8ef0b766cc23be262f5349947c0f2d3c4193b56.
