### PR TITLE
Add zypak and update to 1.60.2

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -60,5 +60,6 @@ for i in "${SDK[@]}"; do
   fi
 done
 
-exec env PATH="${PATH}:${XDG_DATA_HOME}/node_modules/bin" \
-  /app/extra/vscode/bin/code --extensions-dir=${XDG_DATA_HOME}/vscode/extensions "$@" ${WARNING_FILE}
+exec env ELECTRON_RUN_AS_NODE=1 PATH="${PATH}:${XDG_DATA_HOME}/node_modules/bin" \
+  /app/bin/zypak-wrapper.sh /app/extra/vscode/code /app/extra/vscode/resources/app/out/cli.js \
+  --extensions-dir=${XDG_DATA_HOME}/vscode/extensions "$@" ${WARNING_FILE}

--- a/com.visualstudio.code.metainfo.xml
+++ b/com.visualstudio.code.metainfo.xml
@@ -22,6 +22,7 @@
     <content_attribute id="social-info">moderate</content_attribute>
   </content_rating>
   <releases>
+    <release version="1.60.2" date="2021-09-22"/>
     <release version="1.60.1" date="2021-09-14"/>
     <release version="1.57.1-1623936438" date="2021-06-17"/>
     <release version="1.56.2-1620837933" date="2021-05-13"/>

--- a/com.visualstudio.code.metainfo.xml
+++ b/com.visualstudio.code.metainfo.xml
@@ -22,6 +22,7 @@
     <content_attribute id="social-info">moderate</content_attribute>
   </content_rating>
   <releases>
+    <release version="1.60.1" date="2021-09-14"/>
     <release version="1.57.1-1623936438" date="2021-06-17"/>
     <release version="1.56.2-1620837933" date="2021-05-13"/>
     <release version="1.56.1-1620295664" date="2021-05-11"/>

--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -42,6 +42,16 @@ modules:
 
   - shared-modules/libsecret/libsecret.json
 
+  - name: zypak
+    sources:
+      - type: git
+        url: https://github.com/refi64/zypak
+        tag: v2021.09.1
+        commit: e09f37ca4ff09827434deba11f9b1f9e1c42dbaf
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
+
   - name: vscode
     buildsystem: simple
     build-commands:
@@ -89,24 +99,24 @@ modules:
       - type: extra-data
         filename: code.deb
         only-arches: [x86_64]
-        url: http://packages.microsoft.com/repos/code/pool/main/c/code/code_1.57.1-1623937013_amd64.deb
-        sha256: a5a50ec014b27656c198e560796f3b41180f3bdb0c19f0005193f79ed47fc8b8
-        size: 76349788
+        url: https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.60.1-1631294805_amd64.deb
+        sha256: 7606eabb7b38535d6533524876820ed5cdd9b56a47c9d953dd1f3ffcb4aaffbf
+        size: 75903744
         x-checker-data:
           type: debian-repo
           package-name: code
-          root: http://packages.microsoft.com/repos/code
+          root: https://packages.microsoft.com/repos/code
           dist: stable
           component: main
       - type: extra-data
         filename: code.deb
         only-arches: [aarch64]
-        url: http://packages.microsoft.com/repos/code/pool/main/c/code/code_1.57.1-1623936438_arm64.deb
-        sha256: ce23625da8a2399f5ab4f39b65747e0a9d3b9b0258c1d81ea5ceb58a6be6d96b
-        size: 75900590
+        url: https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.60.1-1631293646_arm64.deb
+        sha256: 70b4f0b160a75b2c3bc687298f4ea7cc673a9f3d8f29979fc57ee7c77f1e9a0c
+        size: 74055780
         x-checker-data:
           type: debian-repo
           package-name: code
-          root: http://packages.microsoft.com/repos/code
+          root: https://packages.microsoft.com/repos/code
           dist: stable
           component: main

--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -99,9 +99,9 @@ modules:
       - type: extra-data
         filename: code.deb
         only-arches: [x86_64]
-        url: https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.60.1-1631294805_amd64.deb
-        sha256: 7606eabb7b38535d6533524876820ed5cdd9b56a47c9d953dd1f3ffcb4aaffbf
-        size: 75903744
+        url: https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.60.2-1632313585_amd64.deb
+        sha256: 5d14d85ee907045b0fdc00d02d5f0f2a4336d37747f52862ed64fd52f92dec5b
+        size: 75900200
         x-checker-data:
           type: debian-repo
           package-name: code
@@ -111,9 +111,9 @@ modules:
       - type: extra-data
         filename: code.deb
         only-arches: [aarch64]
-        url: https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.60.1-1631293646_arm64.deb
-        sha256: 70b4f0b160a75b2c3bc687298f4ea7cc673a9f3d8f29979fc57ee7c77f1e9a0c
-        size: 74055780
+        url: https://packages.microsoft.com/repos/code/pool/main/c/code/code_1.60.2-1632312033_arm64.deb
+        sha256: 3159c96c3be2fa11e5a2c8757941e967ece1c6225b597e8fa8ff0494edad072d
+        size: 74036054
         x-checker-data:
           type: debian-repo
           package-name: code

--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -3,6 +3,8 @@ default-branch: stable
 runtime: org.freedesktop.Sdk
 runtime-version: '20.08'
 sdk: org.freedesktop.Sdk
+base: org.electronjs.Electron2.BaseApp
+base-version: '20.08'
 command: code
 tags: [proprietary]
 desktop-file-name-suffix: ' (Flatpak)'
@@ -41,16 +43,6 @@ cleanup:
 modules:
 
   - shared-modules/libsecret/libsecret.json
-
-  - name: zypak
-    sources:
-      - type: git
-        url: https://github.com/refi64/zypak
-        tag: v2021.09.1
-        commit: e09f37ca4ff09827434deba11f9b1f9e1c42dbaf
-        x-checker-data:
-          type: git
-          tag-pattern: ^v([\d.]+)$
 
   - name: vscode
     buildsystem: simple


### PR DESCRIPTION
This pull request adds [zypak](https://github.com/refi64/zypak) and updates Visual Studio Code to [1.60.2](https://code.visualstudio.com/updates/v1_60). While there is already work on adding zypak in #237, it has been stale for almost two months and command line arguments do not appear to work.

In this pull request, command line arguments should still function properly with the exception of `--wait`. I am unaware of a solution for this. Note that the `--reuse-window` command line argument also does not function properly, however this issue exists in previous versions and is not caused by this pull request.

This fixes #223 and fixes #247.