### PR TITLE
Backing to depricated option to Integrated Terminal

### DIFF
--- a/flatpak-warning.txt
+++ b/flatpak-warning.txt
@@ -18,14 +18,14 @@ To execute commands on the host system, run inside the sandbox:
 To make the Integrated Terminal automatically use the host system's shell,
 you can add this to the settings:
 
+
   {
-    "terminal.integrated.defaultProfile.linux": "bash",
-    "terminal.integrated.profiles.linux": {
-        "bash": {
-          "path": "/usr/bin/flatpak-spawn",
-          "args": ["--host", "--env=TERM=xterm-256color", "bash"]
-        }
-    }
+      "terminal.integrated.shell.linux": "/usr/bin/flatpak-spawn",
+        "terminal.integrated.shellArgs.linux": [
+          "--host",
+          "--env=TERM='xterm-256color'",
+          "/bin/bash"
+        ],
   }
 
 This flatpak provides a standard development environment (gcc, python, etc).


### PR DESCRIPTION
The solution for Integrated Terminal doesn't work anymore.

More details of the problem in: https://github.com/flathub/com.visualstudio.code/issues/288