### PR TITLE
Remove Flatpak suffix from icon

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -7,7 +7,6 @@ base: org.electronjs.Electron2.BaseApp
 base-version: '21.08'
 command: code
 tags: [proprietary]
-desktop-file-name-suffix: ' (Flatpak)'
 separate-locales: false
 finish-args:
   - --require-version=0.10.3


### PR DESCRIPTION
Remove the desktop icon name suffix "(Flatpak)" as this is inconsistent with all other apps. Closes #292