### PR TITLE
Update shared modules and enable libusb

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -46,6 +46,8 @@ modules:
 
   - shared-modules/libsecret/libsecret.json
 
+  - shared-modules/libusb/libusb.json
+
   - name: vscode
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Libusb is required by certain command line tools. In my case it is required for openocd included with ESP-IDF.