### PR TITLE
Update Flathub/Gnome Software metadata to solve (very) common issues w/ sandboxed flatpak version.

### DIFF
--- a/com.visualstudio.code.metainfo.xml
+++ b/com.visualstudio.code.metainfo.xml
@@ -8,9 +8,7 @@
   <url type="homepage">https://code.visualstudio.com</url>
   <summary>Visual Studio Code. Code editing. Redefined.</summary>
   <description>
-    <p>IMPORTANT: To use certain features (like the integrated terminal) in this flatpacked version, you will need to <a href="https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak-" target="_blank">follow the quick README here</a>.</p>
-    <p>This is the proprietary Microsoft build of Visual Studio Code, packaged into a Flatpak. This repackaging is not supported by Microsoft.</p>
-    <p>Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle.</p>
+    <p>Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle. This is the proprietary Microsoft build of Visual Studio Code, packaged into a Flatpak. This repackaging is not supported by Microsoft. IMPORTANT: To use certain features in this flatpacked version (like the integrated terminal), you will need to <a href="https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak-" target="_blank">follow the quick README here</a>.</p>
   </description>
   <screenshots>
     <screenshot type="default">

--- a/com.visualstudio.code.metainfo.xml
+++ b/com.visualstudio.code.metainfo.xml
@@ -8,8 +8,9 @@
   <url type="homepage">https://code.visualstudio.com</url>
   <summary>Visual Studio Code. Code editing. Redefined.</summary>
   <description>
-    <p>Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle.</p>
+    <p>IMPORTANT: To use certain features (like the integrated shell) in this flatpacked version, you will need to <a href="https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak-">follow the quick README here</a>.</p>
     <p>This is the proprietary Microsoft build of Visual Studio Code, packaged into a Flatpak. This repackaging is not supported by Microsoft.</p>
+    <p>Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle.</p>
   </description>
   <screenshots>
     <screenshot type="default">

--- a/com.visualstudio.code.metainfo.xml
+++ b/com.visualstudio.code.metainfo.xml
@@ -8,7 +8,9 @@
   <url type="homepage">https://code.visualstudio.com</url>
   <summary>Visual Studio Code. Code editing. Redefined.</summary>
   <description>
-    <p>Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle. This is the proprietary Microsoft build of Visual Studio Code, packaged into a Flatpak. This repackaging is not supported by Microsoft. IMPORTANT: To use certain features in this flatpacked version (like the integrated terminal), you will need to <a href="https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak-" target="_blank">follow the quick README here</a>.</p>
+    <p>Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle.</p>
+    <p>IMPORTANT: To use certain features in this flatpacked version (like the integrated terminal), you will need to <a href="https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak-" target="_blank">follow the quick README here</a>.</p>
+    <p>This is the proprietary Microsoft build of Visual Studio Code, packaged into a Flatpak. This repackaging is not supported by Microsoft.</p>
   </description>
   <screenshots>
     <screenshot type="default">

--- a/com.visualstudio.code.metainfo.xml
+++ b/com.visualstudio.code.metainfo.xml
@@ -8,7 +8,7 @@
   <url type="homepage">https://code.visualstudio.com</url>
   <summary>Visual Studio Code. Code editing. Redefined.</summary>
   <description>
-    <p>IMPORTANT: To use certain features (like the integrated terminal) in this flatpacked version, you will need to <a href="https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak-">follow the quick README here</a>.</p>
+    <p>IMPORTANT: To use certain features (like the integrated terminal) in this flatpacked version, you will need to <a href="https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak-" target="_blank">follow the quick README here</a>.</p>
     <p>This is the proprietary Microsoft build of Visual Studio Code, packaged into a Flatpak. This repackaging is not supported by Microsoft.</p>
     <p>Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle.</p>
   </description>

--- a/com.visualstudio.code.metainfo.xml
+++ b/com.visualstudio.code.metainfo.xml
@@ -8,7 +8,7 @@
   <url type="homepage">https://code.visualstudio.com</url>
   <summary>Visual Studio Code. Code editing. Redefined.</summary>
   <description>
-    <p>IMPORTANT: To use certain features (like the integrated shell) in this flatpacked version, you will need to <a href="https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak-">follow the quick README here</a>.</p>
+    <p>IMPORTANT: To use certain features (like the integrated terminal) in this flatpacked version, you will need to <a href="https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak-">follow the quick README here</a>.</p>
     <p>This is the proprietary Microsoft build of Visual Studio Code, packaged into a Flatpak. This repackaging is not supported by Microsoft.</p>
     <p>Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle.</p>
   </description>


### PR DESCRIPTION
We do this by linking to our new README.md "documentation". A bunch of people may not find it otherwise, so we need a direct link from Gnome Software / KDE / Flathub.org etc.