### PR TITLE
Update Store metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Visual Studio Code Flatpak <!-- omit in toc -->
+# Visual Studio Code Flatpak<!-- omit in toc -->
 
 
 🚨 Warning: This is an unofficial Flatpak build of Visual Studio Code, generated from the official Microsoft-built .deb packages [here](https://github.com/flathub/com.visualstudio.code/blob/master/com.visualstudio.code.yaml#L103).
 
-## Table of Contents <!-- omit in toc -->
+## Table of Contents<!-- omit in toc -->
 
 - [Usage](#usage)
   - [Execute commands in the host system.](#execute-commands-in-the-host-system)

--- a/com.visualstudio.code.metainfo.xml
+++ b/com.visualstudio.code.metainfo.xml
@@ -9,7 +9,7 @@
   <summary>Visual Studio Code. Code editing. Redefined.</summary>
   <description>
     <p>Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle.</p>
-    <p>IMPORTANT: To use certain features in this flatpacked version (like the integrated terminal), you will need to <a href="https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak-" target="_blank">follow the quick README here</a>.</p>
+    <p>IMPORTANT: To use certain features in this flatpacked version (like the integrated terminal), you will need to follow the quick README at https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak-</p>
     <p>This is the proprietary Microsoft build of Visual Studio Code, packaged into a Flatpak. This repackaging is not supported by Microsoft.</p>
   </description>
   <screenshots>

--- a/com.visualstudio.code.metainfo.xml
+++ b/com.visualstudio.code.metainfo.xml
@@ -9,7 +9,7 @@
   <summary>Visual Studio Code. Code editing. Redefined.</summary>
   <description>
     <p>Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle.</p>
-    <p>IMPORTANT: To use certain features in this flatpacked version (like the integrated terminal), you will need to follow the quick README at https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak</p>
+    <p>IMPORTANT: To use certain features in this flatpacked version (like the integrated terminal), please see https://github.com/flathub/com.visualstudio.code#readme</p>
     <p>This is the proprietary Microsoft build of Visual Studio Code, packaged into a Flatpak. This repackaging is not supported by Microsoft.</p>
   </description>
   <screenshots>

--- a/com.visualstudio.code.metainfo.xml
+++ b/com.visualstudio.code.metainfo.xml
@@ -9,7 +9,7 @@
   <summary>Visual Studio Code. Code editing. Redefined.</summary>
   <description>
     <p>Visual Studio Code is a new choice of tool that combines the simplicity of a code editor with what developers need for the core edit-build-debug cycle.</p>
-    <p>IMPORTANT: To use certain features in this flatpacked version (like the integrated terminal), you will need to follow the quick README at https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak-</p>
+    <p>IMPORTANT: To use certain features in this flatpacked version (like the integrated terminal), you will need to follow the quick README at https://github.com/flathub/com.visualstudio.code#visual-studio-code-flatpak</p>
     <p>This is the proprietary Microsoft build of Visual Studio Code, packaged into a Flatpak. This repackaging is not supported by Microsoft.</p>
   </description>
   <screenshots>


### PR DESCRIPTION
Gnome Software & Flathub don't support anchor links in the description apparently - so we move to a simple URL in plain text.

## Current state:
Un-expanded:
![image](https://user-images.githubusercontent.com/20881877/177779234-e65688ba-d7eb-496c-9d09-2341febcc515.png)
Expanded:
![image](https://user-images.githubusercontent.com/20881877/177779148-07670e1e-2190-4d57-ad2d-d39e53b813ab.png)
