### PR TITLE
Always create `/etc/shells` if it's missing

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -60,8 +60,12 @@ for i in "${SDK[@]}"; do
   fi
 done
 
-if [ ! -e /etc/shells ] && [ -e /var/run/host/etc/shells ]; then
-  ln -s /var/run/host/etc/shells /etc/shells
+if [ ! -e /etc/shells ]; then
+  if [ -e /var/run/host/etc/shells ]; then
+    ln -s /var/run/host/etc/shells /etc/shells
+  else
+    touch /etc/shells
+  fi
 fi
 
 exec env ELECTRON_RUN_AS_NODE=1 PATH="${PATH}:${XDG_DATA_HOME}/node_modules/bin" \


### PR DESCRIPTION
Without an existing `/etc/shells` it's no possible to select a prefered
shell with the `Terminal: Select Default Profile` command,
a profile added with `terminal.integrated.profiles.linux` will not be
listed, and it's not possible to set it as default with
`terminal.integrated.defaultProfile.linux`.
So lets always create `/etc/shells`, even if the user blocked host
access.