### PR TITLE
Add fallback content to /etc/shells

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -60,8 +60,12 @@ for i in "${SDK[@]}"; do
   fi
 done
 
-if [ ! -e /etc/shells ] && [ -e /var/run/host/etc/shells ]; then
-  ln -s /var/run/host/etc/shells /etc/shells
+if [ ! -e /etc/shells ]; then
+  if [ -e /var/run/host/etc/shells ]; then
+    ln -s /var/run/host/etc/shells /etc/shells
+  else
+    echo -e "/bin/sh\n/bin/bash" > /etc/shells
+  fi
 fi
 
 exec env ELECTRON_RUN_AS_NODE=1 PATH="${PATH}:${XDG_DATA_HOME}/node_modules/bin" \


### PR DESCRIPTION
When flatpak is run with --nofilesystem=host option, path /var/run/host/etc/shells doesn't exist. So we need to have some content in /etc/shells in this case to provide correct launch of integrated terminal.