### PR TITLE
Add host-spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Visual Studio Code Flatpak<!-- omit in toc -->
 
-
 🚨 Warning: This is an unofficial Flatpak build of Visual Studio Code, generated from the official Microsoft-built .deb packages [here](https://github.com/flathub/com.visualstudio.code/blob/master/com.visualstudio.code.yaml#L103).
 
 ## Table of Contents<!-- omit in toc -->
@@ -11,11 +10,9 @@
   - [Support for language extension.](#support-for-language-extension)
 - [Support](#support)
 
-
 ## Usage
 
 Most functionality works out of the box, though please note that flatpak runs in an isolated environment and some work is necessary to enable those features.
-
 
 ### Execute commands in the host system.
 
@@ -23,13 +20,21 @@ To execute commands on the host system, run inside the sandbox:
 
 `$ flatpak-spawn --host <COMMAND>`
 
+or
+
+`$ host-spawn <COMMAND>`
+
+- Most users seem to report a better experience with `host-spawn`
+
 ### Use host shell in the integrated terminal.
 
 Another option to execute commands is to use your host shell in the integrated terminal instead of the sandbox one.
 
 For that go to `File -> Preferences -> Settings` and find `Terminal > Integrated > Profiles`, then click on `Edit in settings.json` (The important thing here is to open settings.json)
 
-And make sure that you have the following lines there
+And make sure that you have the following lines there:
+
+`flatpak-spawn --host`
 
 ```
 {
@@ -38,11 +43,27 @@ And make sure that you have the following lines there
     "bash": {
       "path": "/usr/bin/flatpak-spawn",
       "args": ["--host", "--env=TERM=xterm-256color", "bash"]
+      "icon": "terminal-bash",
+      "overrideName": true
     }
   }
 }
 ```
-* You can change **bash** to any terminal you are using: zsh, fish, sh.
+
+`host-spawn`
+
+```
+    "terminal.integrated.defaultProfile.linux": "bash",
+    "bash": {
+      "path": "/app/bin/host-spawn",
+      "args": ["bash"],
+      "icon": "terminal-bash",
+      "overrideName": true
+    },
+```
+
+- You can change **bash** to any terminal you are using: zsh, fish, sh.
+- `overrideName` allows for the 'name' (or whatever you set it to) of the shell you're using to appear (e.g. normally zsh, fish, sh).
 
 ### Support for language extension.
 
@@ -51,24 +72,22 @@ Some Visual Studio extension depends on packages that might exist on your host, 
 **See available SDK:**
 
 ```
-  flatpak run --command=sh com.visualstudio.code
-  ls /usr/bin (shared runtime)
-  ls /app/bin (bundled with this flatpak)
+$ flatpak run --command=sh com.visualstudio.code
+$ ls /usr/bin (shared runtime)
+$ ls /app/bin (bundled with this flatpak)
 ```
 
 **Getting support for additional languages, you have to install SDK extensions, e.g.**
 
 ```
-flatpak install flathub org.freedesktop.Sdk.Extension.dotnet
-flatpak install flathub org.freedesktop.Sdk.Extension.golang
-FLATPAK_ENABLE_SDK_EXT=dotnet,golang flatpak run com.visualstudio.code
+$ flatpak install flathub org.freedesktop.Sdk.Extension.dotnet
+$ flatpak install flathub org.freedesktop.Sdk.Extension.golang
+$ FLATPAK_ENABLE_SDK_EXT=dotnet,golang flatpak run com.visualstudio.code
 ```
 
 **Finding other SDK**
 
 `flatpak search <TEXT>`
-
-
 
 ## Support
 

--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -135,6 +135,22 @@ modules:
       - type: file
         path: krb5.conf
 
+  - name: host-spawn
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 host-spawn /app/bin/host-spawn
+    sources: 
+      - type: file 
+        url: https://github.com/1player/host-spawn/releases/download/1.4.0/host-spawn-x86_64
+        sha256: 58376355681d673f310566145e05675fce6e51468d2737c1cafd9500e0b6bbcd
+        dest-filename: host-spawn
+        only-arches: [x86_64]
+      - type: file 
+        url: https://github.com/1player/host-spawn/releases/download/1.4.0/host-spawn-aarch64
+        sha256: 34aee99088117166abc30b8dbcfbc2f1e3dff4b669858373c15e8337a1808f1f
+        dest-filename: host-spawn
+        only-arches: [aarch64]
+
   - name: zypak
     sources:
       - type: git

--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -141,13 +141,13 @@ modules:
       - install -Dm755 host-spawn /app/bin/host-spawn
     sources: 
       - type: file 
-        url: https://github.com/1player/host-spawn/releases/download/1.4.0/host-spawn-x86_64
-        sha256: 58376355681d673f310566145e05675fce6e51468d2737c1cafd9500e0b6bbcd
+        url: https://github.com/1player/host-spawn/releases/download/1.4.1/host-spawn-x86_64
+        sha256: d81bb6125ec73a9a2e26266c48787367fbcb665d67c2e7fb42217f0981106cf7
         dest-filename: host-spawn
         only-arches: [x86_64]
       - type: file 
-        url: https://github.com/1player/host-spawn/releases/download/1.4.0/host-spawn-aarch64
-        sha256: 34aee99088117166abc30b8dbcfbc2f1e3dff4b669858373c15e8337a1808f1f
+        url: https://github.com/1player/host-spawn/releases/download/1.4.1/host-spawn-aarch64
+        sha256: 29bff846d72e37093b3fdf7859bae16addd64acc98087f8c059548df3c2273c4
         dest-filename: host-spawn
         only-arches: [aarch64]
 


### PR DESCRIPTION
Closes #315 #197 #62

This commits add `host-spawn` to this Flatpak in `/app/bin`.

Also, updates the `README.md` with the options to use `host-spawn`.