### PR TITLE
Add instructions to run fish-shell in the terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ And make sure that you have the following lines there
   }
 }
 ```
-* You can change **bash** to any terminal you are using: zsh, fish, sh.
+* You can change **bash** to any terminal you are using: zsh, sh.
+ 
+**Note**: For **fish**, install `com.visualstudio.code.tool.fish` and use the built-in profile (see terminal.integrated.defaultProfile.linux` in Settings)
 
 ### Support for language extension.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ And make sure that you have the following lines there
 ```
 * You can change **bash** to any terminal you are using: zsh, sh.
  
-**Note**: For **fish**, install `com.visualstudio.code.tool.fish` and use the built-in profile (see terminal.integrated.defaultProfile.linux` in Settings)
+**Note**: For **fish**, install `com.visualstudio.code.tool.fish` and use the built-in profile (see `terminal.integrated.defaultProfile.linux` in Settings)
 
 ### Support for language extension.
 


### PR DESCRIPTION
It is not actually possible to use flatpak-spawn to run fish inside the sandbox, it fails with the following error:

```
warning: No TTY for interactive shell (tcgetpgrp failed)
setpgid: Inappropriate ioctl for device
```

This specific problem has been pointed out several times: https://github.com/flatpak/flatpak/issues/3285 https://github.com/flatpak/flatpak/issues/3697 but while other shells work fine printing a warning, fish crashes and does not work at all.

The current widespread solution is to use toolbox+podman to run fish in the host, but that requires installing a lot of dependencies if one does not already use podman. `com.visualstudio.code.tool.fish` has been available for a while but is not usually pointed out as a solution.

It solves the issue and works fine, and one can link their host config into the Flatpak XDG config to share it between host and sandbox.