### PR TITLE
Clean up finish-args

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -18,7 +18,7 @@ finish-args:
   - --device=all
   - --allow=devel
   - --filesystem=host
-  - --filesystem=xdg-config/gtk-3.0
+  - --filesystem=xdg-config/gtk-3.0:ro
   - --filesystem=xdg-config/kdeglobals:ro
   - --env=NPM_CONFIG_GLOBALCONFIG=/app/etc/npmrc
   - --env=LD_LIBRARY_PATH=/app/lib

--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -10,25 +10,25 @@ tags: [proprietary]
 separate-locales: false
 finish-args:
   - --require-version=0.10.3
+  - --share=network
   - --share=ipc
   - --socket=x11
   - --socket=pulseaudio
   - --socket=ssh-auth
-  - --share=network
   - --device=all
-  - --filesystem=xdg-config/gtk-3.0
-  - --filesystem=host
   - --allow=devel
-  - --talk-name=org.freedesktop.Notifications
-  - --talk-name=org.freedesktop.secrets
-  - --talk-name=org.freedesktop.Flatpak
+  - --filesystem=host
+  - --filesystem=xdg-config/gtk-3.0
+  - --filesystem=xdg-config/kdeglobals:ro
   - --env=NPM_CONFIG_GLOBALCONFIG=/app/etc/npmrc
   - --env=LD_LIBRARY_PATH=/app/lib
   - --env=ZYPAK_SPAWN_LATEST_ON_REEXEC=0
-  - --filesystem=xdg-config/kdeglobals:ro
+  - --system-talk-name=org.freedesktop.login1
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.freedesktop.Flatpak
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=com.canonical.AppMenu.Registrar.*
-  - --system-talk-name=org.freedesktop.login1
 add-extensions:
   com.visualstudio.code.tool:
     directory: tools


### PR DESCRIPTION
This change incorporates two commits:
1. Group up the finish-args so that they are easier to read and modify. Also, they are reordered slightly to match the order presented in Flatseal (arbitrarily picked, though I suspect people would appreciate it this way).
2. Mark the `filesystem=xdg-config/gtk-3.0` arg as readonly. I'm not sure why this isn't marked as readonly, especially considering the following `filesystem=xdg-config/kdeglobals:ro` arg _is_ marked as readonly. This change was the primary motivation behind this PR.