### PR TITLE
Add EXTRA_PATH ext to PATH env

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -64,7 +64,7 @@ if [ ! -e /etc/shells ] && [ -e /var/run/host/etc/shells ]; then
   ln -s /var/run/host/etc/shells /etc/shells
 fi
 
-exec env ELECTRON_RUN_AS_NODE=1 PATH="${PATH}:${XDG_DATA_HOME}/node_modules/bin" \
+exec env ELECTRON_RUN_AS_NODE=1 PATH="$EXTRA_PATH:${PATH}:${XDG_DATA_HOME}/node_modules/bin" \
   /app/bin/zypak-wrapper.sh /app/extra/vscode/code /app/extra/vscode/resources/app/out/cli.js \
   --ms-enable-electron-run-as-node --extensions-dir=${XDG_DATA_HOME}/vscode/extensions \
   "$@" ${WARNING_FILE}


### PR DESCRIPTION
add EXTRA_PATH from user flatpak env , ext to apps PATH
#419

for example python pip need `~/.local/bin/` for other  expansions.