### PR TITLE
Fix terminal setup json

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ And make sure that you have the following lines there:
   "terminal.integrated.profiles.linux": {
     "bash": {
       "path": "/usr/bin/flatpak-spawn",
-      "args": ["--host", "--env=TERM=xterm-256color", "bash"]
+      "args": ["--host", "--env=TERM=xterm-256color", "bash"],
       "icon": "terminal-bash",
       "overrideName": true
     }


### PR DESCRIPTION
The json is missing a comma after the args array