### PR TITLE
Install a host-spawn symlink for podman shim

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -139,6 +139,7 @@ modules:
     buildsystem: simple
     build-commands:
       - install -Dm755 host-spawn /app/bin/host-spawn
+      - ln -s host-spawn /app/bin/podman
     sources:
       - type: file
         url: https://github.com/1player/host-spawn/releases/download/1.5.0/host-spawn-x86_64


### PR DESCRIPTION
Install a host-spawn symlink for podman shim

Requires PR #468 to be applied first