### PR TITLE
Add custom flag support

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -64,7 +64,11 @@ if [ ! -e /etc/shells ] && [ -e /var/run/host/etc/shells ]; then
   ln -s /var/run/host/etc/shells /etc/shells
 fi
 
+if [ -f "${XDG_CONFIG_HOME}/code-flags.conf" ]; then
+  mapfile -t USER_FLAGS <<< "$(grep -v '^#' "${XDG_CONFIG_HOME}/code-flags.conf")"
+fi
+
 exec env ELECTRON_RUN_AS_NODE=1 PATH="${PATH}:${XDG_DATA_HOME}/node_modules/bin" \
   /app/bin/zypak-wrapper.sh /app/extra/vscode/code /app/extra/vscode/resources/app/out/cli.js \
   --ms-enable-electron-run-as-node --extensions-dir=${XDG_DATA_HOME}/vscode/extensions \
-  "$@" ${WARNING_FILE}
+  "${USER_FLAGS[@]}" "$@" ${WARNING_FILE}


### PR DESCRIPTION
Allows users to specify persistent flags via `code-flags.conf`file. Implementation taken from [Spotify Flatpak](https://github.com/flathub/com.spotify.Client/commit/7f5ae2665ed0076595168593c150ecd5fffda393).

This is an alternative to #373 that would allow users to fix #281 without their changes being reset every update. It can also potentially be useful for other things, but I imagine this would be the primary use for now.