### PR TITLE
README: Update host-spawn guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ or
 
 Another option to execute commands is to use your host shell in the integrated terminal instead of the sandbox one.
 
-For that go to `File -> Preferences -> Settings` and find `Terminal > Integrated > Profiles`, then click on `Edit in settings.json` (The important thing here is to open settings.json)
+For that go to `File -> Preferences -> Settings` and find `Features > Terminal > Integrated > Profiles`, then click on `Edit in settings.json` (The important thing here is to open settings.json)
 
 And make sure that you have the following lines there:
 
@@ -53,13 +53,17 @@ And make sure that you have the following lines there:
 `host-spawn`
 
 ```
-    "terminal.integrated.defaultProfile.linux": "bash",
+{
+  "terminal.integrated.defaultProfile.linux": "bash",
+  "terminal.integrated.profiles.linux": {
     "bash": {
       "path": "/app/bin/host-spawn",
       "args": ["bash"],
       "icon": "terminal-bash",
       "overrideName": true
-    },
+    }
+  }
+}
 ```
 
 - You can change **bash** to any terminal you are using: zsh, fish, sh.


### PR DESCRIPTION
- There is a Features section at the top level of the settings menu which hides the Terminal section, add that stage to match the current UI
- The host-spawn JSON works, but seems to assume that you're modifying the JSON above, so show the full configuration to make it clear that each works independently of the other

Tested on Fedora and SteamOS.

Fixes #466