### PR TITLE
Remove `zypak` module

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -149,10 +149,3 @@ modules:
         sha256: c42c12be6cdd83e374b847bec836659fb45231215797777c9ee1c9c0ae9e3783
         dest-filename: host-spawn
         only-arches: [aarch64]
-
-  - name: zypak
-    sources:
-      - type: git
-        url: https://github.com/refi64/zypak
-        tag: v2024.01.17
-        commit: ded79a2f8a509adc21834b95a9892073d4a91fdc


### PR DESCRIPTION
`zypak` is included in `org.electronjs.Electron2.BaseApp` since 2020 [1] and was already removed when the vscode flatpak started to use the electron base app [2].

It was added back in PR #300 [3], which was not really necessary, because at the time the PR was merged, `zypak` was already updated in the base app. The author of the PR requested to remove `zypak` again [4], but that never happened.

[1] https://github.com/flathub/org.electronjs.Electron2.BaseApp/pull/10
[2] https://github.com/flathub/com.visualstudio.code/commit/4538e48ac42819f7a4a1d37abb98f676512bb8a0
[3] https://github.com/flathub/com.visualstudio.code/pull/300
[4] https://github.com/flathub/com.visualstudio.code/pull/300#issuecomment-1092647335