### PR TITLE
Remove `libsecret` module

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -41,9 +41,6 @@ cleanup:
   - /share/gtk-doc
   - '*.la'
 modules:
-
-  - shared-modules/libsecret/libsecret.json
-
   - shared-modules/libusb/libusb.json
 
   - name: vscode


### PR DESCRIPTION
libsecret is now included in the electron base app [1].

Closes #486

[1] https://github.com/flathub/org.electronjs.Electron2.BaseApp/pull/53