### PR TITLE
Fix missing icon in wayland

### DIFF
--- a/com.visualstudio.code.desktop
+++ b/com.visualstudio.code.desktop
@@ -7,6 +7,7 @@ Icon=com.visualstudio.code
 Type=Application
 StartupNotify=true
 StartupWMClass=Code
+StartupWMClass=code-url-handler
 Categories=TextEditor;Development;IDE;
 MimeType=text/plain;inode/directory;application/x-code-workspace;
 Actions=new-empty-window;


### PR DESCRIPTION
When running in wayland with `--ozone-platform-hint=auto`, the icon is no longer set at runtime application and must come from the `.desktop` file.

However, the desktop file we ship has a different `StartupWMClass` than what's provided by vs code at runtime. This PR fixes that.