### PR TITLE
Patched for Wayland compatibility

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -64,7 +64,9 @@ if [ ! -e /etc/shells ] && [ -e /var/run/host/etc/shells ]; then
   ln -s /var/run/host/etc/shells /etc/shells
 fi
 
+WAYLAND_FLAGS="--ozone-platform-hint=auto"
+
 exec env ELECTRON_RUN_AS_NODE=1 PATH="${PATH}:${XDG_DATA_HOME}/node_modules/bin" \
   /app/bin/zypak-wrapper.sh /app/extra/vscode/code /app/extra/vscode/resources/app/out/cli.js \
   --ms-enable-electron-run-as-node --extensions-dir=${XDG_DATA_HOME}/vscode/extensions \
-  "$@" ${WARNING_FILE}
+  $WAYLAND_FLAGS "$@" ${WARNING_FILE}

--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --share=network
   - --share=ipc
   - --socket=x11
+  - --socket=wayland
   - --socket=pulseaudio
   - --socket=ssh-auth
   - --device=all

--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -11,8 +11,8 @@ finish-args:
   - --require-version=0.10.3
   - --share=network
   - --share=ipc
-  - --socket=x11
   - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=ssh-auth
   - --device=all


### PR DESCRIPTION
Added a variable `WAYLAND_FLAGS=--ozone-platform-hint=auto` to add to the exec line in code.sh to enable running in Wayland mode on `XDG_SESSION_TYPE=wayland` 

also added `- --socket=wayland` to com.visualstudio.code.yaml to make Wayland socket accesible.