### PR TITLE
Fix #422 - Add missing D-Bus permissions for persistent settings sync on KDE

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -25,6 +25,8 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.freedesktop.Flatpak
+  - --talk-name=org.kde.kwalletd5
+  - --talk-name=org.kde.kwalletd6
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=com.canonical.AppMenu.Registrar.*
 add-extensions:


### PR DESCRIPTION
This adds the missing D-Bus permissions to make settings sync work with KWallet.