### PR TITLE
Set TMPDIR to $XDG_RUNTIME_DIR/app/com.visualstudio.code

### DIFF
--- a/code.sh
+++ b/code.sh
@@ -65,6 +65,7 @@ if [ ! -e /etc/shells ] && [ -e /var/run/host/etc/shells ]; then
 fi
 
 exec env ELECTRON_RUN_AS_NODE=1 PATH="${PATH}:${XDG_DATA_HOME}/node_modules/bin" \
+  TMPDIR="$XDG_RUNTIME_DIR/app/${FLATPAK_ID:-com.visualstudio.code}" \
   /app/bin/zypak-wrapper.sh /app/extra/vscode/code /app/extra/vscode/resources/app/out/cli.js \
   --ms-enable-electron-run-as-node --extensions-dir=${XDG_DATA_HOME}/vscode/extensions \
   "$@" ${WARNING_FILE}


### PR DESCRIPTION
This sets `TMPDIR` to a tmpfs directory shared between the Flatpak vscode and the host, which fixes an issue when using Devcontainers features.

Fixes #605 

`TMPDIR` is used by Node.js [`os.tmpdir()`](https://nodejs.org/api/os.html#ostmpdir) which is used by [devcontainers CLI](https://github.com/devcontainers/cli/tree/eda6cf892e1440d1fbb454d6e457a2343113ded6).

Setting `TMPDIR` to `$XDG_RUNTIME_DIR/app/$FLATPAK_ID` is proposed in [Flatpak documentation](https://docs.flatpak.org/en/latest/sandbox-permissions.html#filesystem-access).