### PR TITLE
Add KDE KWallet D-Bus permissions for credential storage

### DIFF
--- a/com.visualstudio.code.yaml
+++ b/com.visualstudio.code.yaml
@@ -25,6 +25,8 @@ finish-args:
   - --system-talk-name=org.freedesktop.login1
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.kde.kwalletd5
+  - --talk-name=org.kde.kwalletd6
   - --talk-name=org.freedesktop.Flatpak
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=com.canonical.AppMenu.Registrar.*


### PR DESCRIPTION
## Summary
- Add `--talk-name=org.kde.kwalletd5` and `--talk-name=org.kde.kwalletd6` to `finish-args`
- Fixes KDE users getting "OS keyring is not available for encryption" and credentials (e.g. GitHub login) not persisting across restarts

## Context
VS Code detects KDE and attempts to use KWallet for credential storage, but the Flatpak sandbox blocks D-Bus access to the KWallet service. KDE 5 uses `org.kde.kwalletd5`, KDE 6 uses `org.kde.kwalletd6` — both are added for compatibility.

The VSCodium Flatpak (`com.vscodium.codium`) already includes `kwalletd5` in its manifest. The `org.freedesktop.secrets` talk-name already present is not sufficient on KDE desktops.

**Tested on**: Fedora 43, KDE Plasma 6.x — confirmed that adding the `kwalletd6` talk-name via `flatpak override --user` resolves the issue.

Fixes #422